### PR TITLE
Return undefined/default when requesting key nested under null value.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,5 +2,5 @@ export default function dlv(obj, key, def, p) {
 	p = 0;
 	key = key.split ? key.split('.') : key;
 	while (obj && p<key.length) obj = obj[key[p++]];
-	return obj===undefined ? def : obj;
+	return (obj===undefined || p<key.length) ? def : obj;
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "license": "MIT",
   "devDependencies": {
     "rollup": "^0.41.6",
-    "uglifyjs": "^2.4.10"
+    "uglify-js": "^3.2.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -6,6 +6,7 @@ var obj = {
 	zero: 0,
 	one: 1,
 	n: null,
+	f: false,
 	a: {
 		two: 2,
 		b: {
@@ -45,6 +46,8 @@ check('a.b.c', obj.a.b.c);
 check('a.b.c.four', obj.a.b.c.four);
 check('n', obj.n);
 check('n.badkey', undefined);
+check('f', false);
+check('f.badkey', undefined);
 
 //test defaults
 console.log("\n> With Defaults");
@@ -55,6 +58,8 @@ check('n.badkey', 'foo', 'foo');
 check('zero', 0, 'foo');
 check('a.badkey', 'foo', 'foo');
 check('a.badkey.anotherbadkey', 'foo', 'foo');
+check('f', false, 'foo');
+check('f.badkey', 'foo', 'foo');
 
 //check undefined key throws an error
 assert.throws(delve.bind(this, obj, undefined));

--- a/test.js
+++ b/test.js
@@ -43,12 +43,15 @@ check('a.b', obj.a.b);
 check('a.b.three', obj.a.b.three);
 check('a.b.c', obj.a.b.c);
 check('a.b.c.four', obj.a.b.c.four);
+check('n', obj.n);
+check('n.badkey', undefined);
 
 //test defaults
 console.log("\n> With Defaults");
 check('', 'foo', 'foo');
 check('undef', 'foo', 'foo');
 check('n', null, 'foo');
+check('n.badkey', 'foo', 'foo');
 check('zero', 0, 'foo');
 check('a.badkey', 'foo', 'foo');
 check('a.badkey.anotherbadkey', 'foo', 'foo');


### PR DESCRIPTION
Return undefined/default value when requesting for a key nested under a null value.

My logic for this change is:
If we reach an `undefined` object or the end of the key path (`p >= key.length`), we return the object in that position, if that object is `undefined` we return the `default` value, otherwise we rerturn the object. (including `null` values)

When we don't reach the end of the key path (`p < key.length`), it's because a value in between is `falsey`, in either case that mean the object at the end of the key path is unreachable (`undefined`) and we should return the default value.

[Closes #9]