### PR TITLE
Support arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # `dlv(obj, keypath)` [![NPM](https://img.shields.io/npm/v/dlv.svg)](https://npmjs.com/package/dlv) [![Build](https://travis-ci.org/developit/dlv.svg?branch=master)](https://travis-ci.org/developit/dlv)
 
-> Safely get a dot-notated path within a nested object, with ability to return a default if the full key path does not exist or the value is undefined
+> Safely get a path-specified value within a nested object, with ability to return a default if the full key path does not exist or the value is undefined
 
 
 ### Why?
 
-Smallest possible implementation: only **130 bytes.**
+Smallest possible implementation: only **132 bytes.**
 
 You could write this yourself, but then you'd have to write [tests].
 
@@ -29,7 +29,11 @@ let obj = {
 		b: {
 			c: 1,
 			d: undefined,
-			e: null
+			e: null,
+			x: [
+				{y: 8},
+				{z: 9}
+			]
 		}
 	}
 };
@@ -42,11 +46,15 @@ delve(obj, ['a', 'b', 'c']) === 1;
 
 delve(obj, 'a.b') === obj.a.b;
 
+//or access nested objects within an array
+delve(obj, 'a.b.x[1].z') === 9;
+
 //returns undefined if the full key path does not exist and no default is specified
 delve(obj, 'a.b.c.f') === undefined;
 
 //optional third parameter for default if the full key in path is missing
 delve(obj, 'a.b.c.f', 'foo') === 'foo';
+delve(obj, 'a.b.x[2].f', 'foo') === 'foo';
 
 //or if the key exists but the value is undefined
 delve(obj, 'a.b.c.d', 'foo') === 'foo';

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 export default function dlv(obj, key, def, p) {
 	p = 0;
-	key = key.split ? key.split('.') : key;
+	key = key.split ? key.split(/\W+/) : key;
 	while (obj && p<key.length) obj = obj[key[p++]];
 	return (obj===undefined || p<key.length) ? def : obj;
 }

--- a/test.js
+++ b/test.js
@@ -14,7 +14,11 @@ var obj = {
 			c: {
 				four: 4
 			}
-		}
+		},
+		d: [
+			{five: 5},
+			{six: 6}
+		]
 	}
 };
 
@@ -27,7 +31,7 @@ function check(path, value, def) {
 	console.log(' ✓ delve(obj, "'+path+'"'+ (def ? ', "'+def+'"' : '') + ')');
 
 	if (path) {
-		var arr = path.split('.');
+		var arr = path.split(/\W+/);
 		assert.strictEqual(delve(obj, arr, def), value);
 		console.log(' ✓ delve(obj, ' + JSON.stringify(arr) + (def ? ', "'+def+'"' : '') + ')');
 		console.log(' ✓ delve(obj, '+JSON.stringify(arr)+')');
@@ -44,6 +48,7 @@ check('a.b', obj.a.b);
 check('a.b.three', obj.a.b.three);
 check('a.b.c', obj.a.b.c);
 check('a.b.c.four', obj.a.b.c.four);
+check('a.d[1].six', obj.a.d[1].six);
 check('n', obj.n);
 check('n.badkey', undefined);
 check('f', false);
@@ -58,6 +63,7 @@ check('n.badkey', 'foo', 'foo');
 check('zero', 0, 'foo');
 check('a.badkey', 'foo', 'foo');
 check('a.badkey.anotherbadkey', 'foo', 'foo');
+check('a.d[2].missing', 'foo', 'foo');
 check('f', false, 'foo');
 check('f.badkey', 'foo', 'foo');
 


### PR DESCRIPTION
I'm often needing to drill into arrays within nested objects and have paths like the following:

`values.conditions[1].operator`

This PR adds the ability for `dlv` to accept these types of paths, doing a greedy split on word boundaries instead of splitting on dot. Minimal increase in size to 132b.

cc @developit 