### PR TITLE
Square bracket syntax support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `dlv(obj, keypath)` [![NPM](https://img.shields.io/npm/v/dlv.svg)](https://npmjs.com/package/dlv) [![Build](https://travis-ci.org/developit/dlv.svg?branch=master)](https://travis-ci.org/developit/dlv)
 
-> Safely get a dot-notated path within a nested object, with ability to return a default if the full key path does not exist or the value is undefined
+> Safely get a path-specified value within a nested object, with ability to return a default if the full key path does not exist or the value is undefined
 
 
 ### Why?
@@ -29,7 +29,11 @@ let obj = {
 		b: {
 			c: 1,
 			d: undefined,
-			e: null
+			e: null,
+			x: [
+				{ y: 8 },
+				{ z: 9 }
+			]
 		}
 	}
 };
@@ -42,11 +46,15 @@ delve(obj, ['a', 'b', 'c']) === 1;
 
 delve(obj, 'a.b') === obj.a.b;
 
+//or access nested objects within an array
+delve(obj, 'a.b.x[1].z') === 9;
+
 //returns undefined if the full key path does not exist and no default is specified
 delve(obj, 'a.b.c.f') === undefined;
 
 //optional third parameter for default if the full key in path is missing
 delve(obj, 'a.b.c.f', 'foo') === 'foo';
+delve(obj, 'a.b.x[2].f', 'foo') === 'foo';
 
 //or if the key exists but the value is undefined
 delve(obj, 'a.b.c.d', 'foo') === 'foo';

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ### Why?
 
-Smallest possible implementation: only **130 bytes.**
+Smallest possible implementation: only **153 bytes.**
 
 You could write this yourself, but then you'd have to write [tests].
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ### Why?
 
-Smallest possible implementation: only **153 bytes.**
+Smallest possible implementation: only **160 bytes.**
 
 You could write this yourself, but then you'd have to write [tests].
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 export default function dlv(obj, key, def, p) {
 	p = 0;
-	key = key.split ? key.replace(/\[([\w\d]+)\]/g, '.$1').split('.') : key;
+	key = key.split ? key.replace(/\[("|')?([^\[\]]+)\1\]/g, '.$2').split('.') : key;
 	while (obj && p<key.length) obj = obj[key[p++]];
 	return (obj===undefined || p<key.length) ? def : obj;
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 export default function dlv(obj, key, def, p) {
 	p = 0;
-	key = key.split ? key.split('.') : key;
+	key = key.split ? key.replace(/\[([\w\d]+)\]/g, '.$1').split('.') : key;
 	while (obj && p<key.length) obj = obj[key[p++]];
 	return (obj===undefined || p<key.length) ? def : obj;
 }

--- a/test.js
+++ b/test.js
@@ -15,7 +15,11 @@ var obj = {
 				four: 4
 			}
 		}
-	}
+	},
+	foo: {
+		"some property": 8
+	},
+	arr: [4, 3, [9, { bar: false, deep: [false, true] }, 7]]
 };
 
 // assert equality of a given path, as dot notation and array.
@@ -27,7 +31,7 @@ function check(path, value, def) {
 	console.log(' ✓ delve(obj, "'+path+'"'+ (def ? ', "'+def+'"' : '') + ')');
 
 	if (path) {
-		var arr = path.split('.');
+		var arr = path.replace(/\[([\w\d]+)\]/g, '.$1').split(".");
 		assert.strictEqual(delve(obj, arr, def), value);
 		console.log(' ✓ delve(obj, ' + JSON.stringify(arr) + (def ? ', "'+def+'"' : '') + ')');
 		console.log(' ✓ delve(obj, '+JSON.stringify(arr)+')');
@@ -48,6 +52,10 @@ check('n', obj.n);
 check('n.badkey', undefined);
 check('f', false);
 check('f.badkey', undefined);
+check('foo.some property', obj.foo["some property"]);
+check('arr[1]', obj.arr[1]);
+check('arr[2][1].bar', obj.arr[2][1].bar);
+check('arr[2][1].deep[1]', obj.arr[2][1].deep[1]);
 
 //test defaults
 console.log("\n> With Defaults");

--- a/test.js
+++ b/test.js
@@ -31,7 +31,7 @@ function check(path, value, def) {
 	console.log(' ✓ delve(obj, "'+path+'"'+ (def ? ', "'+def+'"' : '') + ')');
 
 	if (path) {
-		var arr = path.replace(/\[([\w\d]+)\]/g, '.$1').split(".");
+		var arr = path.replace(/\[("|')?([^\[\]]+)\1\]/g, '.$2').split(".");
 		assert.strictEqual(delve(obj, arr, def), value);
 		console.log(' ✓ delve(obj, ' + JSON.stringify(arr) + (def ? ', "'+def+'"' : '') + ')');
 		console.log(' ✓ delve(obj, '+JSON.stringify(arr)+')');
@@ -53,6 +53,9 @@ check('n.badkey', undefined);
 check('f', false);
 check('f.badkey', undefined);
 check('foo.some property', obj.foo["some property"]);
+check('foo["some property"]', obj.foo["some property"]);
+check('foo[\'some property\']', obj.foo["some property"]);
+check('foo[some property]', obj.foo["some property"]);
 check('arr[1]', obj.arr[1]);
 check('arr[2][1].bar', obj.arr[2][1].bar);
 check('arr[2][1].deep[1]', obj.arr[2][1].deep[1]);


### PR DESCRIPTION
I realize that this was already attempted in #24, but with a little extra work I was able to support the edge cases mentioned in the thread.

I tested these changes against the `lodash.get` tests and it's mostly compatible. The `lodash.get` tests failing all seem like uncommon edge-cases, so I've opted not to address them.

The following tests from `lodash.get` fail:
```
`dlv` should preserve the sign of `0`
`dlv` should get symbol keyed property values
`dlv` should get a key over a path
`dlv` should not ignore empty brackets
`dlv` should handle empty paths
`dlv` should handle complex paths
`dlv` should follow `path` over non-plain objects
`dlv` should return the default value when `path` is empty
```

This will also address #27 

cc @developit @bwendt-mylo