### PR TITLE
Reduce output size

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
-export default function dlv(obj, key, def, p) {
-	p = 0;
+export default function dlv(obj, key, def, p, undef) {
 	key = key.split ? key.split('.') : key;
-	while (obj && p<key.length) obj = obj[key[p++]];
-	return (obj===undefined || p<key.length) ? def : obj;
+	for (p = 0; p < key.length; p++) {
+		obj = obj ? obj[key[p]] : undef;
+	}
+	return obj === undef ? def : obj;
 }


### PR DESCRIPTION
Before:
```
129 B: dlv.js.gz
 96 B: dlv.js.br
129 B: dlv.es.js.gz
103 B: dlv.es.js.br
200 B: dlv.umd.js.gz
172 B: dlv.umd.js.br
```
After:
```
122 B: dlv.js.gz
 91 B: dlv.js.br
121 B: dlv.es.js.gz
 97 B: dlv.es.js.br
194 B: dlv.umd.js.gz
160 B: dlv.umd.js.br
```