### PR TITLE
Slim down by using a for/in loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 export default function dlv(obj, key, def, p, undef) {
 	key = key.split ? key.split('.') : key;
-	for (p = 0; p < key.length; p++) {
+	for (p in key) {
 		obj = obj ? obj[key[p]] : undef;
 	}
 	return obj === undef ? def : obj;


### PR DESCRIPTION
for/in returns the index for arrays, so this just works. Passes all the tests.

Before:

```
        122 B: dlv.js.gz
         91 B: dlv.js.br
        121 B: dlv.es.js.gz
         97 B: dlv.es.js.br
        198 B: dlv.umd.js.gz
        160 B: dlv.umd.js.br
```

After:

```
        109 B: dlv.js.gz
         83 B: dlv.js.br
        110 B: dlv.es.js.gz
         83 B: dlv.es.js.br
        185 B: dlv.umd.js.gz
        151 B: dlv.umd.js.br
```