### PR TITLE
Turn function into arrow function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-export default function dlv(obj, key, def, p, undef) {
+export default (obj, key, def, p, undef) => {
 	key = key.split ? key.split('.') : key;
 	for (p = 0; p < key.length; p++) {
 		obj = obj ? obj[key[p]] : undef;


### PR DESCRIPTION
Using an arrow function instead of a function the source is smaller, and also the minified code:
```js
export default((a,b,c,d,e)=>{for(b=b.split?b.split("."):b,d=0;d<b.length;d++)a=a?a[b[d]]:e;return a===e?c:a});
```
I'll understand if there is a reason related to performance or similar to not use an arrow function, but I'm making a PR if you consider this to be a good change :smile: 