### PR TITLE
Make loop stop when it doesn't have any more obj to check

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ export default function dlv(obj, key, def, p, undef) {
 	key = key.split ? key.split('.') : key;
 	for (p = 0; p < key.length; p++) {
 		obj = obj ? obj[key[p]] : undef;
+		if(obj === undef) return def;
 	}
 	return obj === undef ? def : obj;
 }


### PR DESCRIPTION
With this change, if you have and object like `{ foo: "bar" }` and you do `dlv(obj, 'foo.bar.foobar.0.whatever')` it will run twice instead of 5 times.

I have objects that are 20 degrees deep in a very performance sensitive app and this saves me quite a few loops

The bundlesize is a little bigger now.
```
Wrote 130 B: dlv.js.gz
         99 B: dlv.js.br
Wrote 130 B: dlv.es.js.gz
        100 B: dlv.es.js.br
Wrote 208 B: dlv.umd.js.gz
        175 B: dlv.umd.js.br
```

Maybe https://github.com/developit/dlv/pull/32#issuecomment-495304365 can be considered as well, I'm just not sure on the performance downsides of for vs .some