### PR TITLE
Shrink by using reduce

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-export default function dlv(obj, key, def, p, undef) {
+export default function dlv(obj, key, def, undef) {
 	key = key.split ? key.split('.') : key;
-	for (p = 0; p < key.length; p++) {
-		obj = obj ? obj[key[p]] : undef;
-	}
+	obj = key.reduce(function(obj, p) {
+		return obj ? obj[p] : undef;
+	}, obj);
 	return obj === undef ? def : obj;
 }


### PR DESCRIPTION
Before:
```
        122 B: dlv.js.gz
         91 B: dlv.js.br
        121 B: dlv.es.js.gz
         97 B: dlv.es.js.br
        198 B: dlv.umd.js.gz
        160 B: dlv.umd.js.br
```
After:
```
        117 B: dlv.js.gz
         82 B: dlv.js.br
        116 B: dlv.es.js.gz
         81 B: dlv.es.js.br
        188 B: dlv.umd.js.gz
        148 B: dlv.umd.js.br
```

this is smaller than the for in patch, and more performant by looking at this esbench. On par with the for loop: https://esbench.com/bench/5ce6eafa4cd7e6009ef6252b
![image](https://user-images.githubusercontent.com/364532/58279565-b8178580-7d6c-11e9-8e6f-732fc3aabf8b.png)
