### PR TITLE
feat!: update minimum Node.js version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
-  - 6
+  - 20
+  - 22
+  - 24
+  - 26

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "license": "MIT",
   "devDependencies": {
     "microbundle": "^0.11.0"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
This is a breaking change

Node.js <= 20 is also EOL
